### PR TITLE
REMOVE duplicate item

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,9 @@ to provide a command-line functionality similar to a Linux distribution on Windo
 &nbsp; 103. [CRUD Operations](https://github.com/FIWARE/tutorials.CRUD-Operations/tree/NGSI-LD) <br/>
 &nbsp; 104. [Concise Payloads](https://github.com/FIWARE/tutorials.Concise/tree/NGSI-LD) <br/>
 &nbsp; 105. [Merge-Patch and Put](https://github.com/FIWARE/tutorials.Merge-Patch-Put/tree/NGSI-LD) <br/>
-&nbsp; 106. [Temporal Operations](https://github.com/FIWARE/tutorials.Short-Term-History/tree/NGSI-LD) <br/>
-&nbsp; 107. [Entity Relationships](https://github.com/FIWARE/tutorials.Entity-Relationships/tree/NGSI-LD) <br/>
-&nbsp; 108. [Subscriptions](https://github.com/FIWARE/tutorials.Subscriptions/tree/NGSI-LD) <br/>
-&nbsp; 109. [Temporal Operations](https://github.com/FIWARE/tutorials.Short-Term-History/tree/NGSI-LD) <br/>
+&nbsp; 106. [Entity Relationships](https://github.com/FIWARE/tutorials.Entity-Relationships/tree/NGSI-LD) <br/>
+&nbsp; 107. [Subscriptions](https://github.com/FIWARE/tutorials.Subscriptions/tree/NGSI-LD) <br/>
+&nbsp; 108. [Temporal Operations](https://github.com/FIWARE/tutorials.Short-Term-History/tree/NGSI-LD) <br/>
 
 
 ### Internet of Things, Robots and third-party systems


### PR DESCRIPTION
The PR removes the duplicate item, because there are two items for 'Temporal Operations'.